### PR TITLE
Use HTTPS instead of HTTP to resolve dependencies

### DIFF
--- a/biojava-genome/pom.xml
+++ b/biojava-genome/pom.xml
@@ -21,7 +21,7 @@
 		<repository>
 			<id>biojava-maven-repo</id>
 			<name>BioJava repository</name>
-			<url>http://www.biojava.org/download/maven/</url>
+			<url>https://www.biojava.org/download/maven/</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>


### PR DESCRIPTION
This fixes a security vulnerability in this project where the `pom.xml`
files were configuring Maven to resolve dependencies over HTTP instead of
HTTPS.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>